### PR TITLE
Remove definition of IAM topologies + add uncertainty handling when rescaling exchanges.

### DIFF
--- a/tests/geo.py
+++ b/tests/geo.py
@@ -1,5 +1,6 @@
 from constructive_geometries import Geomatcher, ConstructiveGeometries
 from wurst import geomatcher
+from wurst.geo import IMAGE_TOPOLOGY, REMIND_TOPOLOGY
 import pytest
 
 
@@ -21,12 +22,14 @@ def test_default_setup():
 
 
 def test_image_added():
+    geomatcher.add_definitions(IMAGE_TOPOLOGY, "IMAGE", relative=True)
     assert ("IMAGE", "OCE") in geomatcher
     g = Geomatcher()
     assert ("IMAGE", "OCE") not in g
 
 
 def test_remind_added():
+    geomatcher.add_definitions(REMIND_TOPOLOGY, "REMIND", relative=True)
     assert ("REMIND", "EUR") in geomatcher
     g = Geomatcher()
     assert ("REMIND", "EUR") not in g

--- a/tests/uncertainty.py
+++ b/tests/uncertainty.py
@@ -1,15 +1,59 @@
 from wurst import rescale_exchange
 import pytest
+import unittest
+import math
 
 
-def test_rescale_exchange_wrong_inputs():
-    with pytest.raises(AssertionError):
-        rescale_exchange([], 4)
-    with pytest.raises(AssertionError):
-        rescale_exchange({}, "four")
+class TestRescaleExchange(unittest.TestCase):
 
+    def test_rescale_exchange_wrong_inputs(self):
+        with self.assertRaises(AssertionError):
+            rescale_exchange([], 4)
+        with self.assertRaises(AssertionError):
+            rescale_exchange({}, "four")
 
-def test_rescale_exchange():
-    given = {"amount": 2, "foo": "bar", "minimum": 7, "uncertainty type": -1}
-    expected = {"amount": 1, "loc": 1, "foo": "bar", "uncertainty type": 0}
-    assert rescale_exchange(given, 0.5) == expected
+    def test_rescale_exchange(self):
+        given = {"amount": 2, "foo": "bar", "minimum": 7, "uncertainty type": -1}
+        expected = {"amount": 1, "loc": 1, "foo": "bar", "uncertainty type": 0}
+        assert rescale_exchange(given, 0.5) == expected
+
+    def test_rescale_no_uncertainty(self):
+        exc = {'amount': 100, 'uncertainty type': 0}
+        scaled_exc = rescale_exchange(exc, 2, remove_uncertainty=False)
+        self.assertEqual(scaled_exc['amount'], 200)
+        self.assertEqual(scaled_exc['uncertainty type'], 0)
+
+    def test_rescale_lognormal(self):
+        exc = {'amount': 100, 'uncertainty type': 2, 'loc': 2, 'scale': 0.5}
+        scaled_exc = rescale_exchange(exc, 2, remove_uncertainty=False)
+        self.assertEqual(scaled_exc['amount'], 200)
+        self.assertEqual(scaled_exc['uncertainty type'], 2)
+        self.assertAlmostEqual(scaled_exc['loc'], 2 + math.log(2), places=5)
+        self.assertEqual(scaled_exc['scale'], 0.5)
+
+    def test_rescale_normal(self):
+        exc = {'amount': 100, 'uncertainty type': 3, 'loc': 100, 'scale': 10}
+        scaled_exc = rescale_exchange(exc, 2, remove_uncertainty=False)
+        self.assertEqual(scaled_exc['amount'], 200)
+        self.assertEqual(scaled_exc['uncertainty type'], 3)
+        self.assertEqual(scaled_exc['loc'], 200)
+        self.assertEqual(scaled_exc['scale'], 20)
+
+    def test_remove_uncertainty(self):
+        exc = {'amount': 100, 'uncertainty type': 3, 'loc': 100, 'scale': 10}
+        scaled_exc = rescale_exchange(exc, 2)
+        self.assertEqual(scaled_exc['amount'], 200)
+        self.assertEqual(scaled_exc['uncertainty type'], 0)
+        self.assertNotIn('scale', scaled_exc)
+        self.assertEqual(scaled_exc['loc'], 200)
+
+    def test_scale_with_negative_factor(self):
+        exc = {'amount': 100, 'uncertainty type': 3, 'loc': 100, 'scale': 10}
+        scaled_exc = rescale_exchange(exc, -2, remove_uncertainty=False)
+        self.assertEqual(scaled_exc['amount'], -200)
+        self.assertEqual(scaled_exc['uncertainty type'], 3)
+        self.assertEqual(scaled_exc['loc'], -200)
+        self.assertEqual(scaled_exc['scale'], 20)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wurst/geo.py
+++ b/wurst/geo.py
@@ -4,5 +4,5 @@ from constructive_geometries import Geomatcher
 
 
 geomatcher = Geomatcher(backwards_compatible=True)
-geomatcher.add_definitions(IMAGE_TOPOLOGY, "IMAGE", relative=True)
-geomatcher.add_definitions(REMIND_TOPOLOGY, "REMIND", relative=True)
+# geomatcher.add_definitions(IMAGE_TOPOLOGY, "IMAGE", relative=True)
+# geomatcher.add_definitions(REMIND_TOPOLOGY, "REMIND", relative=True)

--- a/wurst/transformations/uncertainty.py
+++ b/wurst/transformations/uncertainty.py
@@ -1,24 +1,52 @@
 from numbers import Number
+import math
 
 
 def rescale_exchange(exc, value, remove_uncertainty=True):
-    """Dummy function to rescale exchange amount and uncertainty.
-
-    This depends on some code being separated from Ocelot, which will take a bit of time.
+    """Function to rescale exchange amount and uncertainty.
 
     * ``exc`` is an exchange dataset.
     * ``value`` is a number, to be multiplied by the existing amount.
     * ``remove_uncertainty``: Remove (unscaled) uncertainty data, default is ``True``.
+    If ``False``, uncertainty data is scaled by the same factor as the amount
+    (except for lognormal distributions, where the ``loc`` parameter is scaled by the log of the factor).
+    Currently, does not rescale for Bernoulli, Discrete uniform, Weibull, Gamma, Beta, Generalized Extreme value
+    and Student T distributions.
 
     Returns the modified exchange."""
     assert isinstance(exc, dict), "Must pass exchange dictionary"
     assert isinstance(value, Number), "Constant factor ``value`` must be a number"
 
+    # Scale the amount
     exc["amount"] *= value
 
-    FIELDS = ("shape", "size", "minimum", "maximum")
+    # Scale the uncertainty fields if uncertainty is not being removed
+    if not remove_uncertainty and "uncertainty type" in exc:
+        uncertainty_type = exc["uncertainty type"]
 
-    if remove_uncertainty:
+        # No uncertainty, do nothing
+        if uncertainty_type in {0, 6, 7, 8, 9, 10, 11, 12}:
+            pass
+        elif uncertainty_type in {1, 2, 3, 4, 5}:
+            # Scale "loc" by the log of value for lognormal distribution
+            if "loc" in exc and uncertainty_type == 2:
+                exc["loc"] += math.log(value)
+            elif "loc" in exc:
+                exc["loc"] *= value
+
+            # "scale" stays the same for lognormal
+            # For other distributions, scale "scale" by the absolute value
+            if "scale" in exc and uncertainty_type not in {2}:
+                exc["scale"] *= abs(value)
+
+            # Scale "minimum" and "maximum" by value
+            for bound in ("minimum", "maximum"):
+                if bound in exc:
+                    exc[bound] *= value
+
+    # If remove_uncertainty is True, then remove all uncertainty info
+    elif remove_uncertainty:
+        FIELDS = ("scale", "minimum", "maximum", )
         exc["uncertainty type"] = 0
         exc["loc"] = exc["amount"]
         for field in FIELDS:


### PR DESCRIPTION
I suggest to disable adding the definitions of REMIND and IMAGE topologies for the following reasons:
* maybe `wurst` users have no interest in them -- if they do, they can still add them "manually"
* `wurst` would focus on handling and performing operations on LCA databases only -- leaving the IAM stuff to other tools like `premise`
* `premise` now has those topologies in its data folder, alongside those of MESSAGE, GCAM, T-IAM, etc. When loading wurst in `premise`, it leads to defining topologies twice in case the user wants to use, e.g., IMAGE.


Also adds rescaling of uncertainty parameters, as requested in #20.